### PR TITLE
refactor: remove redundant event_name input from workflow call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,5 @@ jobs:
       packages: write
       security-events: write
     with:
-      event_name: ${{ github.event_name }}
       docker_meta: '[{"name":"fwdark","file":"Dockerfile"}]'
       platforms: "linux/arm64"


### PR DESCRIPTION
## Summary
Removes redundant \`event_name: \${{ github.event_name }}\` input from the reusable workflow call.

\`github.event_name\` (and \`github.ref_name\`) are available directly in all reusable workflows — they don't need to be passed as inputs. Depends on tehw0lf/workflows#28.